### PR TITLE
Bug/file limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ mvn release:perform
 
 ## Using the Project
 
-Add `com.databricks.labs:tika-ocr:0.2` maven dependency to your databricks runtime.
+Add `com.databricks.labs:tika-ocr:0.1.4` maven dependency to your databricks runtime.
 Alternatively, compile this project with maven profile `shaded` enabled to generate an uber jar that you upload to 
 your databricks runtime. You can now read any file, extracting text content from any file format.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ mvn release:perform
 
 ## Using the Project
 
-Add `com.databricks.labs:tika-ocr:0.1` maven dependency to your databricks runtime.
+Add `com.databricks.labs:tika-ocr:0.2` maven dependency to your databricks runtime.
 Alternatively, compile this project with maven profile `shaded` enabled to generate an uber jar that you upload to 
 your databricks runtime. You can now read any file, extracting text content from any file format.
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.databricks.labs</groupId>
     <artifactId>tika-ocr</artifactId>
-    <version>0.1.3-SNAPSHOT</version>
+    <version>0.1.4-SNAPSHOT</version>
     <name>tika-ocr</name>
 
     <url>https://github.com/databrickslabs/tika-ocr</url>

--- a/src/main/scala/com/databricks/labs/tika/TikaExtractor.scala
+++ b/src/main/scala/com/databricks/labs/tika/TikaExtractor.scala
@@ -3,7 +3,6 @@ package com.databricks.labs.tika
 import org.apache.tika.exception.TikaException
 import org.apache.tika.io.TikaInputStream
 import org.apache.tika.metadata.{Metadata, TikaCoreProperties}
-import org.apache.tika.mime.MediaType
 import org.apache.tika.parser.microsoft.OfficeParserConfig
 import org.apache.tika.parser.ocr.TesseractOCRConfig
 import org.apache.tika.parser.pdf.PDFParserConfig
@@ -18,7 +17,7 @@ object TikaExtractor {
   @throws[IOException]
   @throws[SAXException]
   @throws[TikaException]
-  def extract(stream: TikaInputStream, filename: String): TikaContent = {
+  def extract(stream: TikaInputStream, filename: String, writeLimit: Int = -1): TikaContent = {
 
     // Configure each parser if required
     val pdfConfig = new PDFParserConfig
@@ -26,9 +25,7 @@ object TikaExtractor {
     val tesseractConfig = new TesseractOCRConfig
     val parseContext = new ParseContext
 
-    // write limit of -1 means unlimited.
-    // If not set, default is 100000 characters, making process to file for large documents
-    val handler = new BodyContentHandler(-1)
+    val handler = new BodyContentHandler(writeLimit)
     val parser = new AutoDetectParser()
     val metadata = new Metadata()
 

--- a/src/main/scala/com/databricks/labs/tika/TikaExtractor.scala
+++ b/src/main/scala/com/databricks/labs/tika/TikaExtractor.scala
@@ -26,8 +26,10 @@ object TikaExtractor {
     val tesseractConfig = new TesseractOCRConfig
     val parseContext = new ParseContext
 
+    // write limit of -1 means unlimited.
+    // If not set, default is 100000 characters, making process to file for large documents
+    val handler = new BodyContentHandler(-1)
     val parser = new AutoDetectParser()
-    val handler = new BodyContentHandler()
     val metadata = new Metadata()
 
     // To work, we need Tesseract library install natively

--- a/src/main/scala/com/databricks/labs/tika/package.scala
+++ b/src/main/scala/com/databricks/labs/tika/package.scala
@@ -2,6 +2,8 @@ package com.databricks.labs
 
 package object tika {
 
+  val TIKA_MAX_BUFFER_OPTION = "tika.parser.buffer.size"
+
   private[tika] case class TikaContent(
                                         content: String,
                                         contentType: String,

--- a/src/test/scala/com/databricks/labs/tika/TikaExtractorTest.scala
+++ b/src/test/scala/com/databricks/labs/tika/TikaExtractorTest.scala
@@ -96,4 +96,16 @@ class TikaExtractorTest extends AnyFlatSpec with Matchers {
     spark.conf.unset("spark.sql.sources.binaryFile.maxLength")
   }
 
+  it should "be able to process large files" in {
+    val path = Paths.get("src", "test", "resources", "text").toAbsolutePath.toString
+    assertThrows[SparkException] {
+      spark.read.format("tika").option(TIKA_MAX_BUFFER_OPTION, "hello, world").load(path).show()
+    }
+    assertThrows[SparkException] {
+      spark.read.format("tika").option(TIKA_MAX_BUFFER_OPTION, 1).load(path).show()
+    }
+    val df = spark.read.format("tika").option(TIKA_MAX_BUFFER_OPTION, -1).load(path)
+    df.show()
+  }
+
 }


### PR DESCRIPTION
# Error:
`Your document contained more than 100000 characters` 

# Fix:
Passing unlimited byte buffer to `BodyContentHandler` as an option, default to -1 (i.e. unlimited)