### PR TITLE
Update `spark` to version 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,9 +55,9 @@
     <properties>
         <minimum.coverage>80</minimum.coverage>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <scala.version>2.12.14</scala.version>
+        <scala.version>2.12.15</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
-        <spark.version>3.3.2</spark.version>
+        <spark.version>3.5.0</spark.version>
         <java.version>11</java.version>
     </properties>
 
@@ -115,7 +115,7 @@
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-parsers-standard-package</artifactId>
-            <version>2.8.0</version>
+            <version>2.9.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -360,7 +360,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-shade-plugin</artifactId>
-                        <version>3.2.4</version>
+                        <version>3.5.1</version>
                         <executions>
                             <execution>
                                 <phase>package</phase>
@@ -380,8 +380,8 @@
                                         </filter>
                                     </filters>
                                     <transformers>
-                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                        </transformer>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
                                     </transformers>
                                 </configuration>
                             </execution>

--- a/src/main/scala/com/databricks/labs/tika/TikaExtractor.scala
+++ b/src/main/scala/com/databricks/labs/tika/TikaExtractor.scala
@@ -17,12 +17,13 @@ object TikaExtractor {
   @throws[IOException]
   @throws[SAXException]
   @throws[TikaException]
-  def extract(stream: TikaInputStream, filename: String, writeLimit: Int = -1): TikaContent = {
+  def extract(stream: TikaInputStream, filename: String, writeLimit: Int = -1, timeout: Int = 120): TikaContent = {
 
     // Configure each parser if required
     val pdfConfig = new PDFParserConfig
     val officeConfig = new OfficeParserConfig
     val tesseractConfig = new TesseractOCRConfig
+    tesseractConfig.setTimeoutSeconds(timeout) // Set the Tesseract OCR
     val parseContext = new ParseContext
 
     val handler = new BodyContentHandler(writeLimit)

--- a/src/main/scala/com/databricks/labs/tika/TikaFileFormat.scala
+++ b/src/main/scala/com/databricks/labs/tika/TikaFileFormat.scala
@@ -68,6 +68,15 @@ class TikaFileFormat extends FileFormat with DataSourceRegister {
         "] must be passed as an integer. " + exception.getMessage)
     }
 
+    // Tesseract times out after 120 seconds by default, but we may want to modify this.
+    val timeout = Try {
+      options.getOrElse(TESSERACT_TIMEOUT_SECONDS_OPTION, "120").toInt
+    } match {
+      case Success(value) => value
+      case Failure(exception) => throw new SparkException("Option [" + TESSERACT_TIMEOUT_SECONDS_OPTION +
+        "] must be passed as an integer. " + exception.getMessage)
+    }
+
     file: PartitionedFile => {
 
       // Retrieve file information
@@ -93,7 +102,7 @@ class TikaFileFormat extends FileFormat with DataSourceRegister {
         val tikaInputStream = TikaInputStream.get(fileContent)
 
         // Extract text from binary using Tika
-        val tikaContent = TikaExtractor.extract(tikaInputStream, fileName, bufferSize)
+        val tikaContent = TikaExtractor.extract(tikaInputStream, fileName, bufferSize, timeout)
 
         // Write content to a row following schema specs
         // Note: the required schema provided by spark may come in different order than previously defined

--- a/src/main/scala/com/databricks/labs/tika/package.scala
+++ b/src/main/scala/com/databricks/labs/tika/package.scala
@@ -3,6 +3,7 @@ package com.databricks.labs
 package object tika {
 
   val TIKA_MAX_BUFFER_OPTION = "tika.parser.buffer.size"
+  val TESSERACT_TIMEOUT_SECONDS_OPTION = "tika.parser.ocr.timeout"
 
   private[tika] case class TikaContent(
                                         content: String,

--- a/src/test/scala/com/databricks/labs/tika/TikaExtractorTest.scala
+++ b/src/test/scala/com/databricks/labs/tika/TikaExtractorTest.scala
@@ -96,6 +96,15 @@ class TikaExtractorTest extends AnyFlatSpec with Matchers {
     spark.conf.unset("spark.sql.sources.binaryFile.maxLength")
   }
 
+  it should "fail with tesseract timeout" in {
+    val path1 = Paths.get("src", "test", "resources", "text").toAbsolutePath.toString
+    val path2 = Paths.get("src", "test", "resources", "images").toAbsolutePath.toString
+    assertThrows[SparkException] {
+      val df = spark.read.format("tika").option(TESSERACT_TIMEOUT_SECONDS_OPTION, 0).load(path1, path2)
+      df.show()
+    }
+  }
+
   it should "be able to process large files" in {
     val path = Paths.get("src", "test", "resources", "text").toAbsolutePath.toString
     assertThrows[SparkException] {


### PR DESCRIPTION
- Update `TikaFileFormat` syntax based on `spark` 3.5.0 changes
- Upgrade `IOUtils` to `ByteStreams` (based on `spark` 3.5.0 `binaryFiles` implementation)
- Update `scala` to version 2.12.15
- Update `tika-parsers-standard-package` to 2.9.1
- Update `maven-shade-plugin` to 3.5.1
- Add `ServicesResourceTransformer` to help Databricks discover `tika` parsers
- Add `tika.parser.ocr.timeout` option to allow for longer Tesseract timeouts