### PR TITLE
Add `enableXMLOutput` to `TikaExtractor.extract`

### DIFF
--- a/src/main/scala/com/databricks/labs/tika/TikaExtractor.scala
+++ b/src/main/scala/com/databricks/labs/tika/TikaExtractor.scala
@@ -7,7 +7,7 @@ import org.apache.tika.parser.microsoft.OfficeParserConfig
 import org.apache.tika.parser.ocr.TesseractOCRConfig
 import org.apache.tika.parser.pdf.PDFParserConfig
 import org.apache.tika.parser.{AutoDetectParser, ParseContext, Parser}
-import org.apache.tika.sax.BodyContentHandler
+import org.apache.tika.sax.{BodyContentHandler, ToXMLContentHandler, WriteOutContentHandler}
 import org.apache.poi.util.IOUtils
 
 import java.io.IOException
@@ -18,7 +18,7 @@ object TikaExtractor {
   @throws[IOException]
   @throws[SAXException]
   @throws[TikaException]
-  def extract(stream: TikaInputStream, filename: String, writeLimit: Int = -1, timeout: Int = 120, byteArrayMaxOverride: Int = 300000000): TikaContent = {
+  def extract(stream: TikaInputStream, filename: String, writeLimit: Int = -1, timeout: Int = 120, byteArrayMaxOverride: Int = 300000000, enableXMLOutput: Boolean = false): TikaContent = {
 
     // Configure each parser if required
     val pdfConfig = new PDFParserConfig
@@ -27,7 +27,12 @@ object TikaExtractor {
     tesseractConfig.setTimeoutSeconds(timeout) // Set the Tesseract OCR
     val parseContext = new ParseContext
 
-    val handler = new BodyContentHandler(writeLimit)
+    val handler = if (enableXMLOutput) {
+      val xmlHandler = new ToXMLContentHandler()
+      new WriteOutContentHandler(xmlHandler, writeLimit)
+    } else {
+      new BodyContentHandler(writeLimit)
+    }
     val parser = new AutoDetectParser()
     val metadata = new Metadata()
 

--- a/src/main/scala/com/databricks/labs/tika/TikaFileFormat.scala
+++ b/src/main/scala/com/databricks/labs/tika/TikaFileFormat.scala
@@ -68,6 +68,8 @@ class TikaFileFormat extends FileFormat with DataSourceRegister {
     val skipOfficeTempFiles = getOption(options, TIKA_SKIP_OFFICE_TEMP_FILES, "true")(_.toBoolean)
     // Optionally skip password protected documents
     val skipEncryptedFiles = getOption(options, TIKA_SKIP_ENCRYPTED_FILES, "true")(_.toBoolean)
+    // Optionally output XML
+    val enableXMLOutput = getOption(options, TIKA_XML_OUTPUT, "false")(_.toBoolean)
 
     file: PartitionedFile => {
 
@@ -94,7 +96,7 @@ class TikaFileFormat extends FileFormat with DataSourceRegister {
         val tikaInputStream = TikaInputStream.get(fileContent)
 
         // Extract text from binary using Tika
-        val tikaContent = TikaExtractor.extract(tikaInputStream, fileName, bufferSize, timeout, byteArrayMaxOverride)
+        val tikaContent = TikaExtractor.extract(tikaInputStream, fileName, bufferSize, timeout, byteArrayMaxOverride, enableXMLOutput)
 
         // Write content to a row following schema specs
         // Note: the required schema provided by spark may come in different order than previously defined

--- a/src/main/scala/com/databricks/labs/tika/package.scala
+++ b/src/main/scala/com/databricks/labs/tika/package.scala
@@ -9,6 +9,7 @@ package object tika {
   val TIKA_SKIP_OFFICE_TEMP_FILES = "tika.parser.skipOfficeTempFiles"
   val POI_IOUTILS_BYTEARRAYMAXOVERRIDE = "poi.ioutils.byteArrayMaxOverride"
   val TIKA_SKIP_ENCRYPTED_FILES = "tika.parser.skipEncryptedFiles"
+  val TIKA_XML_OUTPUT = "tika.parser.enableXMLOutput"
 
   private[tika] case class TikaContent(
                                         content: String,


### PR DESCRIPTION
- Allow spark option as a boolean via `tika.parser.enableXMLOutput`
- In response to https://github.com/databrickslabs/tika-ocr/issues/45
- Works as expected on test data, but further testing may be warranted